### PR TITLE
MacOS Pal Support: Docs and Code Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![demo3 1](https://github.com/user-attachments/assets/e6f4be6e-788e-453e-9f27-2b61b76755aa)
 
-For now, `fish` and `zsh` are fully supported and testing is done on Linux only. MacOS might just work too.
+`fish` and `zsh` are fully supported on Linux and macOS.
 
 Perhaps unsurprisingly, xkcd [has](https://xkcd.com/1168/) elucidated the core situation inspiring this software:
 
@@ -14,7 +14,23 @@ Perhaps unsurprisingly, xkcd [has](https://xkcd.com/1168/) elucidated the core s
 
 ## Quickstart
 
-It's a single binary that you can just download into any location on your `$PATH`:
+It's a single binary that you can download into any location on your `$PATH`:
+
+macOS (Apple Silicon):
+
+```sh
+curl -L https://github.com/scottyeager/Pal/releases/latest/download/pal-darwin-arm64 -o /usr/local/bin/pal
+chmod +x /usr/local/bin/pal
+```
+
+macOS (Intel):
+
+```sh
+curl -L https://github.com/scottyeager/Pal/releases/latest/download/pal-darwin-amd64 -o /usr/local/bin/pal
+chmod +x /usr/local/bin/pal
+```
+
+Linux (x86_64):
 
 ```sh
 wget https://github.com/scottyeager/Pal/releases/latest/download/pal-linux-amd64 -O /usr/local/bin/pal
@@ -58,7 +74,7 @@ For interactive configuration, run:
 
 ```sh
 pal /config
-# Config saved successfully at ~/.config/pal_helper/config.yaml
+# The command will print where your config was saved (varies by OS)
 ```
 
 ## Abbreviations
@@ -71,6 +87,17 @@ pal2 # Etc
 ```
 
 Both `fish` and `zsh` are supported for abbreviations. If you followed the quickstart, abbreviations will be available in every new shell or after sourcing the shell config file. For more info, see [abbreviations](https://github.com/scottyeager/Pal/blob/main/docs/abbreviations.md).
+
+### Paths
+
+`pal` uses standard OS-specific paths:
+
+- Config file:
+  - macOS: `~/Library/Application Support/pal_helper/config.yaml`
+  - Linux: `~/.config/pal_helper/config.yaml`
+- Abbreviations file (stores suggestions for pal1, pal2, ...):
+  - macOS: `~/Library/Application Support/pal_helper/expansions.txt`
+  - Linux: `~/.local/share/pal_helper/expansions.txt`
 
 ## Autocompletion
 

--- a/abbr/abbr.fish
+++ b/abbr/abbr.fish
@@ -5,7 +5,12 @@ if not set -q pal_prefix
 end
 
 function _pal_get_completion
-    set completions_file ~/.local/share/pal_helper/expansions.txt
+    # Use configured path if provided, otherwise default to XDG path
+    if set -q pal_abbr_file
+        set completions_file $pal_abbr_file
+    else
+        set completions_file ~/.local/share/pal_helper/expansions.txt
+    end
     set suffix (string match -r "$pal_prefix(\d+)" $argv[1] | tail -n1)
 
     # Handle prefix0 specially

--- a/abbr/abbr.zsh
+++ b/abbr/abbr.zsh
@@ -1,5 +1,5 @@
 # File containing the command lines to expand to
-local PAL_ABBR_FILE=~/.local/share/pal_helper/expansions.txt
+local PAL_ABBR_FILE=${PAL_ABBR_FILE:-~/.local/share/pal_helper/expansions.txt}
 # Default prefix value if not set
 local pal_prefix=${pal_prefix:-pal}
 

--- a/abbr/fish.go
+++ b/abbr/fish.go
@@ -2,11 +2,20 @@ package abbr
 
 import (
 	_ "embed"
+	"fmt"
+	"github.com/scottyeager/pal/inout"
 )
 
 //go:embed abbr.fish
 var FishAbbrEmbed string
 
 func GetFishAbbrScript(abbreviationPrefix string) string {
-	return `set -l pal_prefix "` + abbreviationPrefix + `"` + "\n" + FishAbbrEmbed + "\n"
+	path, err := inout.GetAbbrFilePath()
+	if err != nil {
+		// Fallback to Linux default if something goes wrong
+		path = fmt.Sprintf("%s", "~/.local/share/pal_helper/expansions.txt")
+	}
+	return `set -g pal_prefix "` + abbreviationPrefix + `"` + "\n" +
+		`set -g pal_abbr_file "` + path + `"` + "\n" +
+		FishAbbrEmbed + "\n"
 }

--- a/abbr/zsh.go
+++ b/abbr/zsh.go
@@ -2,11 +2,20 @@ package abbr
 
 import (
 	_ "embed"
+	"fmt"
+	"github.com/scottyeager/pal/inout"
 )
 
 //go:embed abbr.zsh
 var ZshAbbrEmbed string
 
 func GetZshAbbrScript(abbreviationPrefix string) string {
-	return `local pal_prefix="` + abbreviationPrefix + `"` + "\n" + ZshAbbrEmbed + "\n"
+	path, err := inout.GetAbbrFilePath()
+	if err != nil {
+		// Fallback to Linux default if something goes wrong
+		path = fmt.Sprintf("%s", "~/.local/share/pal_helper/expansions.txt")
+	}
+	return `local pal_prefix="` + abbreviationPrefix + `"` + "\n" +
+		`export PAL_ABBR_FILE="` + path + `"` + "\n" +
+		ZshAbbrEmbed + "\n"
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -79,7 +79,13 @@ var updateCmd = &cobra.Command{
 		default:
 			return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
 		}
-		updateCmd := fmt.Sprintf(`wget -q https://github.com/scottyeager/Pal/releases/latest/download/%s -O %s && chmod +x %s`, binaryName, execPath, execPath)
+		// macOS typically doesn't ship with wget, so prefer curl there
+		var updateCmd string
+		if runtime.GOOS == "darwin" {
+			updateCmd = fmt.Sprintf(`curl -fsSL https://github.com/scottyeager/Pal/releases/latest/download/%s -o %s && chmod +x %s`, binaryName, execPath, execPath)
+		} else {
+			updateCmd = fmt.Sprintf(`wget -q https://github.com/scottyeager/Pal/releases/latest/download/%s -O %s && chmod +x %s`, binaryName, execPath, execPath)
+		}
 		err = inout.StorePrefix0Command(updateCmd)
 		if err != nil {
 			return fmt.Errorf("error storing update command: %w", err)

--- a/docs/abbreviations.md
+++ b/docs/abbreviations.md
@@ -15,6 +15,8 @@ $ pal3 # Expands to `dir`
 # Multiple lines can also be expanded together, such as with pal123
 ```
 
+Note for zsh users: type the abbreviation (e.g. `pal1`) and press Space to expand. Press Enter afterwards to execute the expanded command.
+
 This eliminates the need to copy and paste command suggestions. The abbreviations will always dynamically expand into the commands suggested by the last bare `pal` command or the equivalent `/cmd` command.
 
 The stored commands that will expand when using the abbreviations can be printed with `/show`:
@@ -68,6 +70,34 @@ Bring this change into open shell sessions by sourcing your config file again:
 ```sh
 source ~/.zshrc
 ```
+
+#### Using abbreviations in zsh
+
+- Type `pal1` then press Space to expand to the first suggestion. Press Enter to run it.
+- Use `pal2`, `pal3`, etc. For multiple lines, `pal123` expands the first three suggestions.
+- Show the stored suggestions at any time with:
+  ```sh
+  pal /show
+  ```
+
+#### Troubleshooting (zsh)
+
+- Enable for the current shell immediately:
+  ```sh
+  source <(pal --zsh)
+  ```
+- Verify Space is bound to the expansion widget:
+  ```sh
+  bindkey ' ' | grep pal-expand-abbr
+  ```
+  If there’s no output, re-run the `source <(pal --zsh)` command above.
+
+#### Paths
+
+The file that stores suggestions (used by `pal1`, `pal2`, …):
+
+- macOS: `~/Library/Application Support/pal_helper/expansions.txt`
+- Linux: `~/.local/share/pal_helper/expansions.txt`
 
 ## Disabling abbreviations
 


### PR DESCRIPTION
# Work Done

- Added info for MacOS user to use Pal as seamlessly as with Linux
- Tested on macOS Intel Sequoia, and it works well (the pal /commit feature was used for the 2 commits of this PR!)
- Added info for how to use zsh with MacOS for Pal